### PR TITLE
🔀 :: Refresh 전략 수정

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -27,8 +27,11 @@ export class AuthController {
   @ApiResponse({ status: 200, description: '발급 성공' })
   @UseGuards(AuthGuard('jwt-refresh'))
   @Post('refresh')
-  async refresh(@User('email') email: string) {
-    return this.authService.refresh(email);
+  async refresh(
+    @User('email') email: string,
+    @User('refreshToken') refreshToken: string,
+  ) {
+    return this.authService.refresh(email, refreshToken);
   }
 
   @ApiOperation({

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -91,7 +91,14 @@ export class AuthService {
     return this.saveUser(email, user._json.picture, student);
   }
 
-  async refresh(email: string) {
+  async refresh(email: string, refreshToken: string) {
+    const user = await this.userRepository.findOne({ where: { email } });
+    if (!user || !user.refreshToken)
+      throw new ForbiddenException('Not found user or Not signed in');
+
+    const matched = await bcrypt.compare(refreshToken, user.refreshToken);
+    if (!matched) throw new ForbiddenException('Not matched Token');
+
     const tokens = await this.getToken(email);
     const hash: string = await bcrypt.hash(tokens.refreshToken, 10);
     await this.userRepository.update(email, { refreshToken: hash });

--- a/src/strategies/rtStrategy.ts
+++ b/src/strategies/rtStrategy.ts
@@ -26,6 +26,6 @@ export class RtStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
       where: { email: payload.email },
     });
     if (!user || !bcrypt.compare(refreshToken, user.refreshToken)) return false;
-    return { ...payload, refreshToken };
+    return payload;
   }
 }

--- a/src/strategies/rtStrategy.ts
+++ b/src/strategies/rtStrategy.ts
@@ -16,16 +16,16 @@ export class RtStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
     const configService = new ConfigService();
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-      secretOrKey: configService.get('ACCESS_TOKEN_SECRET'),
+      secretOrKey: configService.get('REFRESH_TOKEN_SECRET'),
     });
   }
 
   async validate(req: Request, payload: { email: string }) {
-    const refreshToken = req.cookies['refreshToken'];
+    const refreshToken = req.get('authorization').replace('Bearer', '').trim();
     const user = await this.userRepository.findOne({
       where: { email: payload.email },
     });
     if (!user || !bcrypt.compare(refreshToken, user.refreshToken)) return false;
-    return { ...payload };
+    return { ...payload, refreshToken };
   }
 }


### PR DESCRIPTION
- rtStrategy의 secretOrKey가 ACCESS_TOKEN_SECRET에서 가져오던걸 REFRESH_TOKEN_SECRET으로 가져오도록 변경
- validate를 할때 cookie에서 refreshToken을 가져오던걸 authorization에서 가져오도록 변경