### PR TITLE
🔀 :: 원래 자신 정보와 참가중인 동아리만 나오는 디테일페이지에 방과후도 추가 , 유저엔티티에 잘못 매핑되었던것 수정

### DIFF
--- a/src/Entities/User.entity.ts
+++ b/src/Entities/User.entity.ts
@@ -31,7 +31,7 @@ export class User {
 
   @OneToMany(
     () => ClassRegistration,
-    (ClassRegistration) => ClassRegistration.id,
+    (ClassRegistration) => ClassRegistration.user,
   )
   classRegistration: ClassRegistration[];
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -25,12 +25,13 @@ export class UserService {
         'classRegistration.afterSchool',
       ],
     });
+    console.log(userData.classRegistration)
     delete userData.refreshToken;
     const clubs = userData.member.map((member) => {
       return member.club;
     });
 
-    const afterSchools = userData.member.map((member) => {
+    const afterSchools = userData.classRegistration.map((member) => {
       return member.user.classRegistration;
     });
     delete userData.member;

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -25,7 +25,6 @@ export class UserService {
         'classRegistration.afterSchool',
       ],
     });
-    console.log(userData.classRegistration)
     delete userData.refreshToken;
     const clubs = userData.member.map((member) => {
       return member.club;

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -18,15 +18,23 @@ export class UserService {
   async getUserData(email: string) {
     const userData = await this.User.findOne({
       where: { email },
-      relations: ['member', 'member.club'],
+      relations: [
+        'member',
+        'member.club',
+        'classRegistration',
+        'classRegistration.afterSchool',
+      ],
     });
     delete userData.refreshToken;
     const clubs = userData.member.map((member) => {
       return member.club;
     });
 
+    const afterSchools = userData.member.map((member) => {
+      return member.user.classRegistration;
+    });
     delete userData.member;
-    return { userData, clubs };
+    return { userData, clubs, afterSchools };
   }
   async editProfile(urlAddress: UrlDto, email: string) {
     await this.User.update({ email: email }, { userImg: urlAddress.url });


### PR DESCRIPTION
## PR 정보
참여중인 방과후를 마이페이지에 사용할수있도록 반환하게 하였습니다 , user엔티티에 classRegistration에 매핑이 id로 되어있던것 user로 수정
## 작업 결과
- 마이페이지 로직
https://github.com/GSM-MSG/MSG-BackEnd-V2/blob/26225ebe903f83f89f914b97962812785b5df260/src/user/user.service.ts#L17-L38
- 엔티티
https://github.com/GSM-MSG/MSG-BackEnd-V2/blob/b988b6b1053d283f37f904be68cbfc052a79f63a/src/Entities/User.entity.ts#L31-L37
