### PR TITLE
🔀 엔티티들 규칙 적용

### DIFF
--- a/src/Entities/Club.entity.ts
+++ b/src/Entities/Club.entity.ts
@@ -3,7 +3,7 @@ import { Member } from './Member.entity';
 import { Image } from './image.entity';
 import { RequestJoin } from './RequestJoin.entity';
 
-@Entity()
+@Entity({ name: 'club' })
 export class Club {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/Entities/Grade.entity.ts
+++ b/src/Entities/Grade.entity.ts
@@ -1,7 +1,7 @@
 import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { AfterSchool } from './AfterSchool.entity';
 
-@Entity()
+@Entity({ name: 'grade' })
 export class Grade {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/Entities/Member.entity.ts
+++ b/src/Entities/Member.entity.ts
@@ -2,7 +2,7 @@ import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { Club } from './Club.entity';
 import { User } from './User.entity';
 
-@Entity()
+@Entity({ name: 'member' })
 export class Member {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/Entities/Teacher.entity.ts
+++ b/src/Entities/Teacher.entity.ts
@@ -1,10 +1,10 @@
-import { Column, Entity, PrimaryColumn } from "typeorm";
+import { Column, Entity, PrimaryColumn } from 'typeorm';
 
-@Entity()
+@Entity({ name: 'teacher' })
 export class Teacher {
-    @PrimaryColumn()
-    userId: string;
+  @PrimaryColumn()
+  userId: string;
 
-    @Column()
-    password: string;
+  @Column()
+  password: string;
 }

--- a/src/Entities/User.entity.ts
+++ b/src/Entities/User.entity.ts
@@ -3,7 +3,7 @@ import { ClassRegistration } from './ClassRegistration.entity';
 import { Member } from './Member.entity';
 import { RequestJoin } from './RequestJoin.entity';
 
-@Entity()
+@Entity({ name: 'user' })
 export class User {
   @PrimaryColumn()
   email: string;

--- a/src/Entities/image.entity.ts
+++ b/src/Entities/image.entity.ts
@@ -7,7 +7,7 @@ import {
 } from 'typeorm';
 import { Club } from './Club.entity';
 
-@Entity()
+@Entity({ name: 'image' })
 export class Image {
   @PrimaryGeneratedColumn()
   id: number;


### PR DESCRIPTION
두글자 이상인 테이블이름들 스네이크표기법이 아닌 그냥 카멜로 생성되는거 수정 및 한글자들은 소문자로 고정